### PR TITLE
Expose relocation issue with OS X

### DIFF
--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -13,7 +13,7 @@ class XCppTests(jupyter_kernel_test.KernelTests):
     code_hello_world = '#include <iostream>\nstd::cout << "hello, world" << std::endl;'''
 
     # Pager: code that should display something (anything) in the pager
-    # code_page_something = "?std::vector"
+    code_page_something = "?std::vector"
 
     # Samples of code which generate a result value (ie, some text
     # displayed as Out[n])
@@ -36,11 +36,11 @@ class XCppTests(jupyter_kernel_test.KernelTests):
     # You can also write extra tests. We recommend putting your kernel name
     # in the method name, to avoid clashing with any tests that
     # jupyter_kernel_test adds in the future.
-    #def test_xcpp_stderr(self):
-    #    reply, output_msgs = self.execute_helper(code='#include <iostream>\nstd::cerr << "oops" << std::endl;')
-    #    self.assertEqual(output_msgs[0]['msg_type'], 'stream')
-    #    self.assertEqual(output_msgs[0]['content']['name'], 'stderr')
-    #    self.assertEqual(output_msgs[0]['content']['text'], 'oops')
+    def test_xcpp_stderr(self):
+        reply, output_msgs = self.execute_helper(code='#include <iostream>\nstd::cerr << "oops" << std::endl;')
+        self.assertEqual(output_msgs[0]['msg_type'], 'stream')
+        self.assertEqual(output_msgs[0]['content']['name'], 'stderr')
+        self.assertEqual(output_msgs[0]['content']['text'], 'oops')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This exposes the relocation issue in #2.

`?std::vector` requires reading a local "tag" file.

When using a locally built package, this works well, but when using the conda package, it makes use of the system's C runtime, and crashes.

cc @mingwandroid we discussed this a while ago, and I gave up on this issue for some time.