### PR TITLE
Rebuild osx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,18 +39,12 @@ requirements:
     - clangdev {{ clang_version|join('.') }}
     - clang_variant * cling_v{{ cling_version }}
     - cling {{ cling_version }}
-    # Strong run exports from clangxx_osx-64 don't pin libcxx.
-    # Cling does require the same version of libcxx to be used.
-    - {{ pin_compatible('libcxx', exact=True) }}  # [osx]
   run:
     # Even though cppzmq, xtl and nlohmann_json are header-only,
     # they are used at runtime by the c++ interpreter.
     - {{ pin_compatible('cppzmq', max_pin='x.x') }}
     - {{ pin_compatible('xtl', max_pin='x.x') }}
     - {{ pin_compatible('nlohmann_json', max_pin='x.x') }}
-    # Strong run exports from clangxx_osx-64 don't pin libcxx.
-    # Cling does require the same version of libcxx to be used.
-    - {{ pin_compatible('libcxx', exact=True) }}  # [osx]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   # Cling has not been built for windows yet
   skip: true  # [win]
   run_exports:


### PR DESCRIPTION
xeus-cling currently pins libcxx at 0.9.0 ##HASH## whereas xwidgets has a requirement on libcxx 0.9.1 

Therefore it doesn't work right now on OS X.

cc @marimeireles