### PR TITLE
Build with last build of xeus and relax constraint on nlohmann_json

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - llvmdev {{ clang_version[0] }}
     - clangdev {{ clang_version|join('.') }} cling_v{{ cling_version }}*
     - cling {{ cling_version }}
+    - libcxx <15
   run:
     # Even though cppzmq, xtl and nlohmann_json are header-only,
     # they are used at runtime by the c++ interpreter.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # Cling has not been built for windows yet
   skip: true  # [win or aarch64]
   run_exports:
@@ -32,7 +32,7 @@ requirements:
     - xtl >=0.7,<0.8
     - pugixml
     - cpp-argparse >=2.9,<3
-    - nlohmann_json >=3.9.1,<3.10
+    - nlohmann_json
     - dirent >=1.21,<2.0  # [win]
     - zlib
     - llvmdev {{ clang_version[0] }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make  # [unix]
+    - libcxx <15
   host:
     - cppzmq >=4.6.0,<5
     - xeus-zmq >=1.0.1,<2.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
